### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,14 +3,14 @@ Repository for the [Xamarin.Forms in Anger](https://www.syntaxismyui.com/categor
 
 Are you a skeptic of the promise of Xamarin.Forms? Do you believe that with Xamarin.Forms you can build native cross-platform UI’s with a single C# codebase? Early on I struggled with the choice of whether to use Xamarin.Forms or a combination of Xamarin.iOS and Xamarin.Android.
 
-##On the Xamarin.Forms Fence
+## On the Xamarin.Forms Fence
 
 To be completely honest, I am no longer a Xamarin.Forms skeptic, but, I do have some reservations about its ability to make good looking cross-platform UI’s. I know that Xamarin.Forms can make developer level UI’s. You know what I mean; it works — but its ugly!
 
 What can a design conscious developer do when faced with the possibility of a bad UI? Scream? Run away? Move to HTML5? No, that won’t do. It’s time to get angry and swing Xamarin.Forms with all our might.
 
 
-##UI Samples
+## UI Samples
 
 * Find a Vet
 * Phoenix Peaks


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
